### PR TITLE
Add 0.61 and 0.62 changeset

### DIFF
--- a/Change_Log.txt
+++ b/Change_Log.txt
@@ -302,3 +302,12 @@ Version 0.59:
 Version 0.60:
 - Fixed scaling problem when loading an SVG file with 'Reduced Memory Use' enabled.
   The problem only occurred if the user was prompted for additional scaling information.
+  
+Version 0.61:
+- Added option in the General Settings to disable waiting for the laser to finish the job after the last data has been sent to the laser.  This can be used to allow the user to start loading the next design as the laser finishes executing the the final data.
+
+Version 0.62:
+- Fixed problem when using M3 Nano board, new job finished code is now detected. 
+- Fixed problem when using M3 Nano board, laser no longer remains on while moving back to starting position after raster engraving.
+- Fixed registration issue between raster and vector operations when custom rapid speed was used.
+- Added Option in the Tools menu that may unfreeze the controller after a job is improperly terminated (will not always work)

--- a/egv.py
+++ b/egv.py
@@ -2,7 +2,7 @@
 '''
 This script reads/writes egv format
 
-Copyright (C) 2017-2020 Scorch www.scorchworks.com
+Copyright (C) 2017-2022 Scorch www.scorchworks.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -682,6 +682,7 @@ class egv:
         self.write(ord("S"))
         self.write(ord("1"))
         self.write(ord("E"))
+        self.write(ord("U"))
 
         if pad:
             self.make_dir_dist(cspad,cspad)
@@ -695,10 +696,11 @@ class egv:
         new_data=[]
         modal_value = -1
         for code in EGV_data:
-            if code == modal_value:
+            if code == modal_value and modal_value != E:
                 continue
             elif (code == self.RIGHT) or (code == self.LEFT) or \
-                 (code == self.UP   ) or (code == self.DOWN) or (code == E):
+                 (code == self.UP   ) or (code == self.DOWN) or \
+                 (code == self.ANGLE) or (code == E):
                 modal_value = code
             new_data.append(code)
         return new_data

--- a/nano_library.py
+++ b/nano_library.py
@@ -2,7 +2,7 @@
 '''
 This script comunicated with the K40 Laser Cutter.
 
-Copyright (C) 2017-2021 Scorch www.scorchworks.com
+Copyright (C) 2017-2022 Scorch www.scorchworks.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -45,11 +45,12 @@ class K40_CLASS:
         self.read_length= 168
 
         #### RESPONSE CODES ####
-        self.OK             = 206
-        self.BUFFER_FULL    = 238
-        self.CRC_ERROR      = 207
-        self.TASK_COMPLETE  = 236
-        self.UNKNOWN_2      = 239 #after failed initialization followed by succesful initialization
+        self.OK               = 206
+        self.BUFFER_FULL      = 238
+        self.CRC_ERROR        = 207
+        self.TASK_COMPLETE    = 236
+        self.UNKNOWN_2        = 239 #after failed initialization followed by succesful initialization
+        self.TASK_COMPLETE_M3 = 204
         #######################
         self.hello   = [160]
         self.unlock  = [166,0,73,83,50,80,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,70,166,15]
@@ -98,10 +99,11 @@ class K40_CLASS:
                 else:
                     print (".",)
             
-            if response[1]==self.OK            or \
-               response[1]==self.BUFFER_FULL   or \
-               response[1]==self.CRC_ERROR     or \
-               response[1]==self.TASK_COMPLETE or \
+            if response[1]==self.OK               or \
+               response[1]==self.BUFFER_FULL      or \
+               response[1]==self.CRC_ERROR        or \
+               response[1]==self.TASK_COMPLETE    or \
+               response[1]==self.TASK_COMPLETE_M3 or \
                response[1]==self.UNKNOWN_2:
                 return response[1]
             else:
@@ -130,6 +132,13 @@ class K40_CLASS:
     def pause_un_pause(self):
         try:
             self.send_data([ord('P'),ord('N')])
+        except:
+            pass
+
+    def unfreeze(self):
+        try:
+            self.send_data([ord('F'),ord('N'),ord('S'),ord('E')])
+            print("unfreeze sent")
         except:
             pass
         
@@ -287,7 +296,7 @@ class K40_CLASS:
         FINISHED = False
         while not FINISHED:
             response = self.say_hello()
-            if response == self.TASK_COMPLETE:
+            if response == self.TASK_COMPLETE or response == self.TASK_COMPLETE_M3:
                 FINISHED = True
                 break
             elif response == None:


### PR DESCRIPTION
Version 0.61:
 - Added option in the General Settings to disable waiting for the laser to finish the job after the last data has been sent to the laser.  This can be used to allow the user to start loading the next design as the laser finishes executing the the final data.

 Version 0.62:
 - Fixed problem when using M3 Nano board, new job finished code is now detected. 
 - Fixed problem when using M3 Nano board, laser no longer remains on while moving back to starting position after raster engraving.
 - Fixed registration issue between raster and vector operations when custom rapid speed was used.
 - Added Option in the Tools menu that may unfreeze the controller after a job is improperly terminated (will not always work)